### PR TITLE
Added checks that productions sites have WP_ENV = production

### DIFF
--- a/child-theme/footer.php
+++ b/child-theme/footer.php
@@ -8,7 +8,7 @@
  */
 ?>
 
-	</div>
+	</div> <!-- // site-content -->
 
 	<footer class="site-footer" role="contentinfo">
 		<div class="site-branding">
@@ -19,4 +19,4 @@
 <?php wp_footer(); ?>
 
 </body>
-</html><!-- FRANTIC SERVER STATUS: OK -->
+</html><?php if ((getenv('WP_DEV') == false || strtolower(getenv('WP_DEV') !== 'true')) && getenv('WP_ENV') != 'production'){ ?><!-- FRANTIC SERVER STATUS: OK --><?php } ?>

--- a/child-theme/inc/admin-features.php
+++ b/child-theme/inc/admin-features.php
@@ -30,6 +30,13 @@ function force_login() {
 	auth_redirect();
 }
 
+if ((getenv('WP_DEV') == false || strtolower(getenv('WP_DEV') !== 'true')) && getenv('WP_ENV') != 'production') {
+    add_filter('login_message', 'development_message');
+    function development_message($message) {
+        return '<p class="message" style="border-left: 4px solid #FFBA00;">' . wp_kses(__('<strong>Note:</strong> You are about to login to a development environment', '_frc'), 'strong') . '</p>';
+    }
+}
+
 /**
  * Actions to be taken in DEVELOPMENT
  * Useful for development and staging enviroments


### PR DESCRIPTION
If we have this we can have the default WP_ENV set as at least staging in bedrock-on-heroku. Devs would notice that the env isn't set to production on production sites on two ways.
1. Login screen would show notification "Note: You are about to login to a development environment"
2. Pingdom alerts that the site is down, when env is not production.
    - Crawling is disabled so I think this is ok.
    - Live production site is not set as production